### PR TITLE
[iOS] Initialize this variable before use

### DIFF
--- a/iOS/DaysUntilXmasiPad/MainViewController.cs
+++ b/iOS/DaysUntilXmasiPad/MainViewController.cs
@@ -446,7 +446,7 @@ namespace DaysUntilXmasiPad
 		public string GetSocialCountdownString()
 		{
 			var pageNumber = GetPageNumber ();
-			string time, unit = "";
+			string time = "", unit = "";
 			switch (pageNumber) {
 			case 0:
 				time = _time.DaysUntil;


### PR DESCRIPTION
The compiler is erroring out because it is possible this var could
be used before it's initialized.
